### PR TITLE
rename ints with long (pointers are longs)

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -51,13 +51,13 @@ void next()
     if (tk == '\n')
     {
       if (src) {
-        printf("%d: %.*s", line, p - lp, lp);
+        printf("%ld: %.*s", line, p - lp, lp);
         lp = p;
         while (le < e) {
           printf("%8.4s", "LEA ,IMM ,JMP ,JSR ,BZ  ,BNZ ,ENT ,ADJ ,LEV ,LI  ,LC  ,SI  ,SC  ,PSH ,"
                           "OR  ,XOR ,AND ,EQ  ,NE  ,LT  ,GT  ,LE  ,GE  ,SHL ,SHR ,ADD ,SUB ,MUL ,DIV ,MOD ,"
                           "OPEN,READ,CLOS,PRTF,MALC,MSET,MCMP,EXIT," + *++le * 5);
-          if (*le <= ADJ) printf(" %d\n", *++le); else printf("\n"); 
+          if (*le <= ADJ) printf(" %ld\n", *++le); else printf("\n"); 
         }
       }
       ++line;
@@ -128,7 +128,7 @@ long expr(long lev)
 {
   long t, *d;
 
-  if (!tk) { printf("%d: unexpected eof in expression", line); exit(-1); }
+  if (!tk) { printf("%ld: unexpected eof in expression", line); exit(-1); }
   else if (tk == Num) { *++e = IMM; *++e = ival; next(); ty = INT; }
   else if (tk == '"') {
     *++e = IMM; *++e = ival; next();
@@ -144,7 +144,7 @@ long expr(long lev)
       next();
       if (d[Class] == Sys) *++e = d[Val];
       else if (d[Class] == Fun) { *++e = JSR; *++e = d[Val]; }
-      else { printf("%d: bad function call\n", line); exit(-1); }
+      else { printf("%ld: bad function call\n", line); exit(-1); }
       if (t) { *++e = ADJ; *++e = t; }
       ty = d[Type];
     } else {
@@ -152,7 +152,7 @@ long expr(long lev)
       else {
         if (d[Class] == Loc) { *++e = LEA; *++e = loc - d[Val]; }
         else if (d[Class] == Glo) { *++e = IMM; *++e = d[Val]; }
-        else { printf("%d: undefined variable\n", line); exit(-1); }
+        else { printf("%ld: undefined variable\n", line); exit(-1); }
         *++e = ((ty = d[Type]) == CHAR) ? LC : LI;
       }
     }
@@ -162,23 +162,23 @@ long expr(long lev)
     if (tk == Int || tk == Char) {
       t = (tk == Int) ? INT : CHAR; next();
       while (tk == Mul) { next(); t = t + PTR; }
-      if (tk == ')') next(); else { printf("%d: bad cast", line); exit(-1); }
+      if (tk == ')') next(); else { printf("%ld: bad cast", line); exit(-1); }
       expr(Inc);
       ty = t;
     }
     else {
       expr(Assign);
-      if (tk == ')') next(); else { printf("%d: close paren expected\n", line); exit(-1); }
+      if (tk == ')') next(); else { printf("%ld: close paren expected\n", line); exit(-1); }
     }
   }
   else if (tk == Mul) {
     next(); expr(Inc);
-    if (ty > INT) ty = ty - PTR; else { printf("%d: bad dereference\n", line); exit(-1); }
+    if (ty > INT) ty = ty - PTR; else { printf("%ld: bad dereference\n", line); exit(-1); }
     *++e = (ty == CHAR) ? LC : LI;
   }
   else if (tk == And) {
     next(); expr(Inc);
-    if (*e == LC || *e == LI) --e; else { printf("%d: bad address-of\n", line); exit(-1); }
+    if (*e == LC || *e == LI) --e; else { printf("%ld: bad address-of\n", line); exit(-1); }
     ty = ty + PTR;
   }
   else if (tk == '!') { next(); expr(Inc); *++e = PSH; *++e = IMM; *++e = 0; *++e = EQ; ty = INT; }
@@ -192,26 +192,26 @@ long expr(long lev)
     t = tk; next(); expr(Inc);
     if (*e == LC) { *e = PSH; *++e = LC; }
     else if (*e == LI) { *e = PSH; *++e = LI; }
-    else { printf("%d: bad lvalue in pre-increment\n", line); exit(-1); }
+    else { printf("%ld: bad lvalue in pre-increment\n", line); exit(-1); }
     *++e = PSH;
     *++e = IMM; *++e = (ty > PTR) ? 4 : 1;
     *++e = (t == Inc) ? ADD : SUB;
     *++e = (ty == CHAR) ? SC : SI;
   }
-  else { printf("%d: bad expression %c\n", line, tk); exit(-1); }
+  else { printf("%ld: bad expression %c\n", line, tk); exit(-1); }
 
   while (tk >= lev) { // "precedence climbing" or "Top Down Operator Precedence" method
     t = ty;
     if (tk == Assign) {
       next();
-      if (*e == LC || *e == LI) *e = PSH; else { printf("%d: bad lvalue in assignment\n", line); exit(-1); }
+      if (*e == LC || *e == LI) *e = PSH; else { printf("%ld: bad lvalue in assignment\n", line); exit(-1); }
       expr(Assign); *++e = ((ty = t) == CHAR) ? SC : SI;
     }
     else if (tk == Cond) {
       next();
       *++e = BZ; d = ++e;
       expr(Assign);
-      if (tk == ':') next(); else { printf("%d: conditional missing colon\n", line); exit(-1); }
+      if (tk == ':') next(); else { printf("%ld: conditional missing colon\n", line); exit(-1); }
       *d = (long)(e + 3); *++e = JMP; d = ++e;
       expr(Cond);
       *d = (long)(e + 1);
@@ -245,7 +245,7 @@ long expr(long lev)
     else if (tk == Inc || tk == Dec) {
       if (*e == LC) { *e = PSH; *++e = LC; }
       else if (*e == LI) { *e = PSH; *++e = LI; }
-      else { printf("%d: bad lvalue in post-increment\n", line); exit(-1); }
+      else { printf("%ld: bad lvalue in post-increment\n", line); exit(-1); }
       *++e = PSH; *++e = IMM; *++e = (ty > PTR) ? 4 : 1;
       *++e = (tk == Inc) ? ADD : SUB;
       *++e = (ty == CHAR) ? SC : SI;
@@ -255,13 +255,13 @@ long expr(long lev)
     }
     else if (tk == Brak) {
       next(); *++e = PSH; expr(Assign);
-      if (tk == ']') next(); else { printf("%d: close bracket expected\n", line); exit(-1); }  
+      if (tk == ']') next(); else { printf("%ld: close bracket expected\n", line); exit(-1); }  
       if (t > PTR) { *++e = PSH; *++e = IMM; *++e = 4; *++e = MUL;  }
-      else if (t < PTR) { printf("%d: pointer type expected\n", line); exit(-1); }
+      else if (t < PTR) { printf("%ld: pointer type expected\n", line); exit(-1); }
       *++e = ADD;
       *++e = ((ty = t - PTR) == CHAR) ? LC : LI;
     }
-    else { printf("%d: compiler error tk=%d\n", line, tk); exit(-1); }
+    else { printf("%ld: compiler error tk=%ld\n", line, tk); exit(-1); }
   }
 }
 
@@ -270,9 +270,9 @@ long stmt()
   long *a, *b;
   if (tk == If) {
     next();
-    if (tk == '(') next(); else { printf("%d: open paren expected\n", line); exit(-1); }  
+    if (tk == '(') next(); else { printf("%ld: open paren expected\n", line); exit(-1); }  
     expr(Assign);
-    if (tk == ')') next(); else { printf("%d: close paren expected\n", line); exit(-1); }  
+    if (tk == ')') next(); else { printf("%ld: close paren expected\n", line); exit(-1); }  
     *++e = BZ; b = ++e;
     stmt();
     if (tk == Else) {
@@ -284,9 +284,9 @@ long stmt()
   } else if (tk == While) {
     next();
     a = e + 1;
-    if (tk == '(') next(); else { printf("%d: open paren expected\n", line); exit(-1); }  
+    if (tk == '(') next(); else { printf("%ld: open paren expected\n", line); exit(-1); }  
     expr(Assign);
-    if (tk == ')') next(); else { printf("%d: close paren expected\n", line); exit(-1); }  
+    if (tk == ')') next(); else { printf("%ld: close paren expected\n", line); exit(-1); }  
     *++e = BZ; b = ++e;
     stmt();
     *++e = JMP; *++e = (long)a;
@@ -295,7 +295,7 @@ long stmt()
     next();
     if (tk != ';') expr(Assign);
     *++e = LEV;
-    if (tk == ';') next(); else { printf("%d: semicolon expected\n", line); exit(-1); }  
+    if (tk == ';') next(); else { printf("%ld: semicolon expected\n", line); exit(-1); }  
   } else if (tk == '{') {
     next();
     while (tk != 0 && tk != '}') stmt();
@@ -304,7 +304,7 @@ long stmt()
     next();
   } else {
     expr(Assign);
-    if (tk == ';') next(); else { printf("%d: semicolon expected\n", line); exit(-1); }
+    if (tk == ';') next(); else { printf("%ld: semicolon expected\n", line); exit(-1); }
   }
 }
 
@@ -320,10 +320,10 @@ int main(int argc, char **argv)
   if ((fd = open(*argv, 0)) < 0) { printf("could not open(%s)\n", *argv); return -1; }
 
   poolsz = 256*1024;
-  if (!(sym = malloc(poolsz))) { printf("could not malloc(%d) symbol area\n", poolsz); return -1; }
-  if (!(le = e = malloc(poolsz))) { printf("could not malloc(%d) text area\n", poolsz); return -1; }
-  if (!(data = malloc(poolsz))) { printf("could not malloc(%d) data area\n", poolsz); return -1; }
-  if (!(sp = malloc(poolsz))) { printf("could not malloc(%d) stack area\n", poolsz); return -1; }
+  if (!(sym = malloc(poolsz))) { printf("could not malloc(%ld) symbol area\n", poolsz); return -1; }
+  if (!(le = e = malloc(poolsz))) { printf("could not malloc(%ld) text area\n", poolsz); return -1; }
+  if (!(data = malloc(poolsz))) { printf("could not malloc(%ld) data area\n", poolsz); return -1; }
+  if (!(sp = malloc(poolsz))) { printf("could not malloc(%ld) stack area\n", poolsz); return -1; }
 
   memset(sym,  0, poolsz);
   memset(e,    0, poolsz);
@@ -335,8 +335,8 @@ int main(int argc, char **argv)
   i = OPEN; while (i <= EXIT) { next(); id[Class] = Sys; id[Type] = INT; id[Val] = i++; } // add library to symbol table
   next(); idmain = id; // keep track of main
 
-  if (!(lp = p = malloc(poolsz))) { printf("could not malloc(%d) source area\n", poolsz); return -1; }
-  if ((i = read(fd, p, poolsz-1)) <= 0) { printf("read() returned %d\n", i); return -1; }
+  if (!(lp = p = malloc(poolsz))) { printf("could not malloc(%ld) source area\n", poolsz); return -1; }
+  if ((i = read(fd, p, poolsz-1)) <= 0) { printf("read() returned %ld\n", i); return -1; }
   p[i] = 0;  
   close(fd);
 
@@ -354,11 +354,11 @@ int main(int argc, char **argv)
         next();
         i = 0;
         while (tk != 0 && tk != '}') {
-          if (tk != Id) { printf("%d: bad enum identifier %d\n", line, tk); return -1; }
+          if (tk != Id) { printf("%ld: bad enum identifier %ld\n", line, tk); return -1; }
           next();
           if (tk == Assign) {
             next();
-            if (tk != Num) { printf("%d: bad enum initializer\n", line); return -1; }
+            if (tk != Num) { printf("%ld: bad enum initializer\n", line); return -1; }
             i = ival;
             next();
           }
@@ -371,8 +371,8 @@ int main(int argc, char **argv)
     while (tk != 0 && tk != ';' && tk != '}') {
       t = bt;
       while (tk == Mul) { next(); t = t + PTR; }
-      if (tk != Id) { printf("%d: bad global declaration\n", line); return -1; }
-      if (id[Class]) { printf("%d: duplicate global definition\n", line); return -1; }
+      if (tk != Id) { printf("%ld: bad global declaration\n", line); return -1; }
+      if (id[Class]) { printf("%ld: duplicate global definition\n", line); return -1; }
       d = id;
       next();
       d[Type] = t;
@@ -385,8 +385,8 @@ int main(int argc, char **argv)
           if (tk == Int) next();
           else if (tk == Char) { next(); t = CHAR; }
           while (tk == Mul) { next(); t = t + PTR; }
-          if (tk != Id) { printf("%d: bad parameter declaration\n", line); return -1; }
-          if (id[Class] == Loc) { printf("%d: duplicate parameter definition\n", line); return -1; }
+          if (tk != Id) { printf("%ld: bad parameter declaration\n", line); return -1; }
+          if (id[Class] == Loc) { printf("%ld: duplicate parameter definition\n", line); return -1; }
           id[HClass] = id[Class]; id[Class] = Loc;
           id[HType]  = id[Type];  id[Type] = t;
           id[HVal]   = id[Val];   id[Val] = i++;
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
           if (tk == ',') next();
         }
         next();
-        if (tk != '{') { printf("%d: bad function definition\n", line); return -1; }
+        if (tk != '{') { printf("%ld: bad function definition\n", line); return -1; }
         loc = ++i;
         next();
         while (tk == Int || tk == Char) {
@@ -403,8 +403,8 @@ int main(int argc, char **argv)
           while (tk != 0 && tk != ';') {
             t = bt;
             while (tk == Mul) { next(); t = t + PTR; }
-            if (tk != Id) { printf("%d: bad local declaration\n", line); return -1; }
-            if (id[Class] == Loc) { printf("%d: duplicate local definition\n", line); return -1; }
+            if (tk != Id) { printf("%ld: bad local declaration\n", line); return -1; }
+            if (id[Class] == Loc) { printf("%ld: duplicate local definition\n", line); return -1; }
             id[HClass] = id[Class]; id[Class] = Loc;
             id[HType]  = id[Type];  id[Type] = t;
             id[HVal]   = id[Val];   id[Val] = ++i;
@@ -450,11 +450,11 @@ int main(int argc, char **argv)
   while (1) {
     i = *pc++; ++cycle;
     if (debug) {
-      printf("%d> %.4s", cycle,
+      printf("%ld> %.4s", cycle,
         "LEA ,IMM ,JMP ,JSR ,BZ  ,BNZ ,ENT ,ADJ ,LEV ,LI  ,LC  ,SI  ,SC  ,PSH ,"
         "OR  ,XOR ,AND ,EQ  ,NE  ,LT  ,GT  ,LE  ,GE  ,SHL ,SHR ,ADD ,SUB ,MUL ,DIV ,MOD ,"
         "OPEN,READ,CLOS,PRTF,MALC,MSET,MCMP,EXIT," + i * 5);
-      if (i <= ADJ) printf(" %d\n", *pc); else printf("\n"); 
+      if (i <= ADJ) printf(" %ld\n", *pc); else printf("\n"); 
     }                    
     if      (i == LEA) a = (long)(bp + *pc++);                             // load local address
     else if (i == IMM) a = *pc++;                                         // load global address or immediate
@@ -495,7 +495,7 @@ int main(int argc, char **argv)
     else if (i == MALC) a = (long)malloc(*sp);
     else if (i == MSET) a = (long)memset((char *)sp[2], sp[1], *sp);
     else if (i == MCMP) a = memcmp((char *)sp[2], (char *)sp[1], *sp);
-    else if (i == EXIT) { printf("exit(%d) cycle = %d\n", *sp, cycle); return *sp; }
-    else { printf("unknown instruction = %d! cycle = %d\n", i, cycle); return -1; }
+    else if (i == EXIT) { printf("exit(%ld) cycle = %ld\n", *sp, cycle); return *sp; }
+    else { printf("unknown instruction = %ld! cycle = %ld\n", i, cycle); return -1; }
   }
 }


### PR DESCRIPTION
I think my system was having trouble because `sizeof(int) != sizeof(int*)`

I swapped a long for the int, since `sizeof(long) == sizeof(long*)`, and all worked well.

`main` does still require an int parameter. This in essence introduced a 2nd tokens for numberics `"int"` and `"long"`.

As it stands, this works for `c4 hello.c`, but not for `c4 c4.c hello.c`.

I did not understand the symbol lookup table well enough to introduce the `int` type back in, so it blows up on that character.

Down to 10 warnings. haven't touched pedantic.

Hope this helps.

Thanks for the great mind puzzle
