### PR TITLE
Fix a compile error from missing include

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 char *p, *lp, // current position in source code
      *data;   // data/bss pointer


### PR DESCRIPTION
open() needs the <fcntl.h> include so this has been added.

Issue brought up in #21.