### PR TITLE
Avoid undefined behavior (variable bp not initialized)

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -335,6 +335,8 @@ int main(int argc, char **argv)
   int *pc, *sp, *bp, a, cycle; // vm registers
   int i, *t; // temps
 
+  bp = 0; // avoid undefined behavior
+
   --argc; ++argv;
   if (argc > 0 && **argv == '-' && (*argv)[1] == 's') { src = 1; --argc; ++argv; }
   if (argc > 0 && **argv == '-' && (*argv)[1] == 'd') { debug = 1; --argc; ++argv; }


### PR DESCRIPTION
When one runs

`./c4 -s hello.c`

the output is

```
1: #include <stdio.h>
2:
3: int main()
4: {
5:   printf("hello, world\n");
    ENT  0
    IMM  9433072
    PSH
    PRTF
    ADJ  1
6:   return 0;
    IMM  0
    LEV
7: }
    LEV
```

Now look what happens when this is interpreted by c4:

`ENT 0`

runs through

`else if (i == ENT) { *--sp = (int)bp; bp = sp; sp = sp - *pc++; }     // enter subroutine`

The problem is: When this line is executed for the first time, `bp` has not yet been initialized. Using the value of an uninitialized variable is undefined behavior in C - thus not permitted. When one compiles the code under Visual C++ 17 in Debug/x86 mode, this will indeed trigger a debug breakpoint (this is how I found the bug).

This little patch fixes this undefined behavior.