### PR TITLE
Made c4 also compile under Windows/Visual Studio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ c4 - C in four functions
 
 An exercise in minimalism.
 
-Try the following:
+Try the following under GNU/Linux:
 
     gcc -o c4 c4.c  (you may need the -m32 option on 64bit machines)
     ./c4 hello.c
@@ -11,4 +11,14 @@ Try the following:
     
     ./c4 c4.c hello.c
     ./c4 c4.c c4.c hello.c
+
+
+Try the following under Microsoft Windows/Visual Studio 2017 in the "x86 Native Tools Command Prompt for VS 2017" or "x64_x86 Cross Tools Command Prompt for VS 2017":
+
+    cl c4.c
+    c4 hello.c
+    c4 -s hello.c
+    
+    c4 c4.c hello.c
+    c4 c4.c c4.c hello.c
 

--- a/c4.c
+++ b/c4.c
@@ -9,7 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 
 char *p, *lp, // current position in source code


### PR DESCRIPTION
I added two lines in c4.c surrounding the

`#include <unistd.h>`

with

```
#ifdef _WIN32
...
#endif
```
to make c4 compile and run under Windows/Visual Studio, since `unistd.h` does not exist under Windows/Visual Studio (it is a very UNIX-specific header). Note that despite looking otherwise the macro `_WIN32 ` is defined **both** when the conpilation target is 32 bit and 64 bit (cf. https://msdn.microsoft.com/en-us/library/b0084kay.aspx for reference) - thus adding this line does not add a future liability to consider when it should be planned to port c4 to 64 bit.

I also added instructions to README.md in similar spirit to the existing guidelines how to do the same "experiments" in a suitable "Command Prompt for VS 2017".
