### PR TITLE
Allow Compilation on Windows by Swapping out <unistd.h> Header

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -9,7 +9,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
-#include <unistd.h>
+#ifdef _WIN32
+	#include <io.h>
+#else
+	#include <unistd.h>
+#endif
 #include <fcntl.h>
 
 char *p, *lp, // current position in source code

--- a/c4.c
+++ b/c4.c
@@ -9,11 +9,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
-#ifdef _WIN32
-	#include <io.h>
-#else
+
+// IF COMPILING ON WINDOWS:
+//	#include <io.h>
+// ELSE:
 	#include <unistd.h>
-#endif
+// ENDIF
+
 #include <fcntl.h>
 
 char *p, *lp, // current position in source code


### PR DESCRIPTION
I added comments to make it effortless for someone to swap out the `unistd.h` header in order to compile on Windows. I realized that a preprocessor directive would not work since that is unsupported so the comments should be the best alternative.