### PR TITLE
fix clang compile error from issue #64

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -330,7 +330,9 @@ void stmt()
   }
 }
 
+#undef int
 int main(int argc, char **argv)
+#define int long long
 {
   int fd, bt, ty, poolsz, *idmain;
   int *pc, *sp, *bp, a, cycle; // vm registers


### PR DESCRIPTION
error: first parameter of 'main' (argument count) must be of type 'int'