### PR TITLE
fix compile error: first parameter of 'main' (argument count) must be of type 'int'

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -330,7 +330,7 @@ void stmt()
   }
 }
 
-int main(int argc, char **argv)
+signed main(signed argc, char **argv)
 {
   int fd, bt, ty, poolsz, *idmain;
   int *pc, *sp, *bp, a, cycle; // vm registers


### PR DESCRIPTION
when I compile c4 file in mac：
➜  c4 git:(master) gcc -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.5 (clang-1205.0.22.11)
Target: x86_64-apple-darwin20.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin


➜  c4 git:(master) gcc -w c4.c
c4.c:333:5: error: first parameter of 'main' (argument count) must be of type 'int'
int main(int argc, char **argv)
    ^
1 error generated.


so, change int to signed fix this error


