### PR TITLE
Fixes int needing to be the same width as int* for armv7l also

### DIFF
--- a/c4.c
+++ b/c4.c
@@ -11,7 +11,7 @@
 #include <memory.h>
 #include <unistd.h>
 #include <fcntl.h>
-#define int long long
+#define int intptr_t
 
 char *p, *lp, // current position in source code
      *data;   // data/bss pointer


### PR DESCRIPTION
With HEAD, I kept always error about usage when I tried the commands in README.md. The input filename wasn't being read in correctly.

This is slightly sloppy since stdint.h isn't being explicitly included. :) I didn't pull it in explicitly to avoid any possible future issues with self-compiling.

I tested this on Debian Linux on: ARM 32-bit armv7l, ARM 64-bit aarch64, and x86_64.

```
<lots of warning during compilation>
$ ./c4 hello.c
usage: c4 [-s] [-d] file ...
$ uname -a
Linux raspberrypi 5.15.32-v7l+ #1538 SMP Thu Mar 31 19:39:41 BST 2022 armv7l GNU/Linux
$ gcc --version
gcc (Raspbian 10.2.1-6+rpi1) 10.2.1 20210110

```
With the patch:

```
<no warning during compilation>
$ ./c4 c4.c c4.c hello.c
hello, world
exit(0) cycle = 9
exit(0) cycle = 26015
exit(0) cycle = 10060161
$ uname -a
Linux raspberrypi 5.15.32-v7l+ #1538 SMP Thu Mar 31 19:39:41 BST 2022 armv7l GNU/Linux
$ gcc --version
gcc (Raspbian 10.2.1-6+rpi1) 10.2.1 20210110
```

Verified that this works on x86_64 [WSL]:
    gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
    Linux DESKTOP 5.10.102.1-microsoft-standard-WSL2 #1 SMP Wed Mar 2 00:30:59 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

and 64-bit Debian on ARM:
    gcc (Debian 10.2.1-6) 10.2.1 20210110
    Linux lepotato 5.10.102-meson64 #22.02.1 SMP PREEMPT Sun Feb 27 09:09:25 UTC 2022 aarch64 GNU/Linux
